### PR TITLE
default.nix: drop `st` alias

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,8 +10,5 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp ate $out/bin
-
-    # for compat
-    ln -s $out/bin/ate $out/bin/st
   '';
 }


### PR DESCRIPTION
This creates more problems than it works around, assuming st is present
in the system closure too.