### PR TITLE
Fork before executing pipecmd

### DIFF
--- a/main.c
+++ b/main.c
@@ -64,18 +64,20 @@ void accel_get_text(GtkAccelGroup *accel_group, GObject *acceleratable,
 
   char *text = vte_terminal_get_text(terminal, NULL, NULL, NULL);
 
-  printf("text: %s\n", text);
+  if (fork() == 0) {
+    FILE *fd = popen(PIPECMD, "w");
+    if (fd == NULL) {
+      free(text);
+      exit(1);
+      return;
+    }
 
-  FILE *fd = popen(PIPECMD, "w");
-
-  if (fd == NULL) {
+    fwrite(text, 1, strlen(text), fd);
+    fflush(fd);
+    fclose(fd);
     free(text);
-    return;
+    exit(0);
   }
-
-  fwrite(text, 1, strlen(text), fd);
-  fflush(fd);
-  fclose(fd);
 
   free(text);
 }


### PR DESCRIPTION
the pipecmd (usually used for URL selection) blocks execution of ATE. If you launch the first instance of your browser then this will block the terminal and render it unresponsive. By forking before the command is executed we can fix that.


cc @mweinelt