### PR TITLE
default.nix: stop using gnome3.vte

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ in
 stdenv.mkDerivation {
   name = "ate-1.1.0";
 
-  buildInputs = [ gnome3.vte or pkgs.vte ];
+  buildInputs = [ pkgs.vte ];
   nativeBuildInputs = [ pkgconfig gnumake makeWrapper wrapGAppsHook ];
 
   # filter the .nix files from the repo


### PR DESCRIPTION
The alias was changed to an error. Trying to evaluate ate in a system
configuration with a recent (4a94071fb3e4fddc8b98dc13104ac720eceb728c) nixpkgs fails like this:

> error: The ‘gnome.vte’ alias was removed on 2022-01-13. Please use ‘pkgs.vte’ directly.

With this change, my system evaluates successfully again.